### PR TITLE
Fix HTTP method label

### DIFF
--- a/src/data/debug.jsx
+++ b/src/data/debug.jsx
@@ -87,7 +87,7 @@ export function delayedFetch(url, options) {
   const { delay, path } = getRequestConfig(url);
   const request = addRequest(path, {
     id: requestId,
-    label: `GET ${url}`,
+    label: `${options?.method || "GET"} ${url}`,
     start: Date.now(),
     done: false,
     delay: delay,


### PR DESCRIPTION
Wrong method is displayed for POST request in the debugger.

<img width="950" height="400" alt="image" src="https://github.com/user-attachments/assets/fed783d6-c3d7-4aea-a67b-553628791e5a" />
