### PR TITLE
Fix delay unit lebel from seconds to milliseconds

### DIFF
--- a/src/debugger.js
+++ b/src/debugger.js
@@ -129,7 +129,7 @@ function NetworkRequest({ label, id, api, row }) {
     input.value = api.delay;
     input.addEventListener("input", (e) => {
       setDelay(id, e.target.value);
-      span.textContent = e.target.value + "s";
+      span.textContent = e.target.value + "ms";
     });
     controls.appendChild(span);
     controls.appendChild(input);


### PR DESCRIPTION
It should be milliseconds and it's used as milliseconds in the TimedProgress