### PR TITLE
Fix view transition stalling with empty onDefaultTransitionIndicator

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -69,5 +69,7 @@ export default function App() {
   );
 }
 
-const root = createRoot(document.getElementById("root"), {});
+const root = createRoot(document.getElementById("root"), {
+	onDefaultTransitionIndicator: () => {}
+});
 root.render(<App />);


### PR DESCRIPTION
Workaround for the issue described in https://github.com/facebook/react/issues/35015