### PR TITLE
pull out optimistic updates out of transitions

### DIFF
--- a/src/design/CompleteButton.jsx
+++ b/src/design/CompleteButton.jsx
@@ -8,8 +8,8 @@ export default function CompleteButton({ complete, action }) {
   const [optimisticComplete, setOptimisticComplete] = useOptimistic(complete);
 
   function clickAction() {
+    setOptimisticComplete(!optimisticComplete);
     startTransition(async () => {
-      setOptimisticComplete(!optimisticComplete);
       await action();
     });
   }

--- a/src/design/SearchInput.jsx
+++ b/src/design/SearchInput.jsx
@@ -14,8 +14,8 @@ export default function SearchInput({ value, changeAction }) {
   const isPending = inputValue !== value;
   function handleChange(e) {
     const newValue = e.target.value;
+    setInputValue(newValue);
     startTransition(async () => {
-      setInputValue(newValue);
       await changeAction(newValue);
     });
   }

--- a/src/design/TabList.jsx
+++ b/src/design/TabList.jsx
@@ -7,8 +7,8 @@ export default function TabList({ activeTab, changeAction, children }) {
   const [optimisticTab, setActiveTab] = useOptimistic(activeTab);
 
   function onTabClick(newValue) {
+    setActiveTab(newValue);
     startTransition(async () => {
-      setActiveTab(newValue);
       await changeAction(newValue);
     });
   }


### PR DESCRIPTION
Optimistic update calls should happen immediately, hence they should not be inside transitions because transitions are for slow/deferred updates.